### PR TITLE
Fix: Use direct copy for yarn installation in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,8 @@ RUN apt-get update && \
         restic gpg mariadb-client less libpq-dev postgresql-client wait-for-it jq && \
     rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g yarn --verbose
+COPY --from=node:18.18.2-alpine /usr/local/bin/yarn /usr/local/bin/yarn
+COPY --from=node:18.18.2-alpine /opt/yarn* /opt/
 
 # ----------- Builder stage ----------
 FROM base AS builder


### PR DESCRIPTION
Replaces the `npm install -g yarn` command with a direct copy of the yarn binary and its related files from the official node image. This is done to avoid potential network issues with npm during the Docker build process, which was causing build failures.

This change mirrors the approach used in other similar projects and aims to improve the reliability of the Docker image build.