### PR TITLE
Debug: Add verbosity and isolate steps to find build hang

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -92,7 +92,7 @@ jobs:
           tags: ${{ env.FINAL_TAGS }}
           build-args: |
             ${{ env.BUILD_ARGS }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,12 +33,14 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install nvm, node, yarn
-RUN mkdir -p ${NVM_DIR} && \
-    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash && \
-    . ${NVM_DIR}/nvm.sh && \
-    nvm install ${NODE_VERSION} && \
+RUN set -x && mkdir -p ${NVM_DIR} && \
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+RUN set -x && . ${NVM_DIR}/nvm.sh && \
+    nvm install ${NODE_VERSION}
+RUN set -x && . ${NVM_DIR}/nvm.sh && \
     nvm use v${NODE_VERSION} && \
-    npm install -g yarn && \
+    npm install -g yarn
+RUN set -x && . ${NVM_DIR}/nvm.sh && \
     nvm alias default v${NODE_VERSION} && \
     rm -rf ${NVM_DIR}/.cache && \
     echo "export NVM_DIR=/home/frappe/.nvm" >> /home/frappe/.bashrc && \
@@ -63,7 +65,9 @@ USER frappe
 WORKDIR /home/frappe
 ARG FRAPPE_PATH=https://github.com/frappe/frappe
 ARG FRAPPE_BRANCH
-RUN bench init /home/frappe/frappe-bench     --frappe-branch=${FRAPPE_BRANCH}     --frappe-path=${FRAPPE_PATH}     --no-procfile     --no-backups     --skip-redis-config-generation     --verbose
+RUN echo "Starting bench init..."
+RUN set -x && bench init /home/frappe/frappe-bench     --frappe-branch=${FRAPPE_BRANCH}     --frappe-path=${FRAPPE_PATH}     --no-procfile     --no-backups     --skip-redis-config-generation     --verbose
+RUN echo "Finished bench init."
 
 # Handle apps.json
 RUN if [ -n "${APPS_JSON_BASE64}" ]; then echo "${APPS_JSON_BASE64}" | base64 -d > /opt/frappe/apps.json; fi


### PR DESCRIPTION
This commit introduces changes to help diagnose an extremely long Docker build time.

Modifications:
- Dockerfile:
    - Separated the nvm, node, and yarn installation commands in the `base` stage into individual `RUN` steps.
    - Added `set -x` to each of these new `RUN` steps for verbose shell output.
    - Added `echo` statements before and after the `bench init` command in the `builder` stage.
    - Added `set -x` to the `bench init` command.
- .github/workflows/autobuild.yml:
    - Temporarily changed the build platforms from `linux/amd64,linux/arm64` to just `linux/amd64` to simplify and speed up the debugging process.

These changes are intended to provide detailed logs that will help identify which specific command or step is causing the build to hang or take an excessive amount of time.