### PR TITLE
Debug: Split cleanup commands to isolate failure

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -92,7 +92,7 @@ jobs:
           tags: ${{ env.FINAL_TAGS }}
           build-args: |
             ${{ env.BUILD_ARGS }}
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,18 +76,25 @@ RUN echo "Cleaning up .git directory from frappe app after bench init..." && \
 RUN if [ -n "${APPS_JSON_BASE64}" ]; then echo "${APPS_JSON_BASE64}" | base64 -d > /opt/frappe/apps.json; fi
 COPY apps.json /home/frappe/frappe-bench/apps.json
 RUN /home/frappe/scripts/install_apps.sh
-RUN echo "Starting comprehensive cleanup of apps and bench directories..." && \
-    find /home/frappe/frappe-bench/apps -name .git -type d -print -exec rm -rf {} \; && \
-    find /home/frappe/frappe-bench/apps -name .github -type d -print -exec rm -rf {} \; && \
-    find /home/frappe/frappe-bench/apps -name node_modules -type d -print -exec rm -rf {} \; && \
-    find /home/frappe/frappe-bench/apps -name '*.pyc' -type f -print -delete && \
-    find /home/frappe/frappe-bench/apps -name '*.pyo' -type f -print -delete && \
-    find /home/frappe/frappe-bench/apps -name '__pycache__' -type d -print -exec rm -rf {} \; && \
-    echo "Cleaning up main bench node_modules and bower_components..." && \
-    rm -rf /home/frappe/frappe-bench/sites/.assets/node_modules && \
-    rm -rf /home/frappe/frappe-bench/node_modules && \
-    rm -rf /home/frappe/frappe-bench/bower_components && \
-    echo "Comprehensive cleanup done."
+RUN echo "Cleaning .git directories from apps..." && \
+    find /home/frappe/frappe-bench/apps -name .git -type d -print -exec rm -rf {} \;
+RUN echo "Cleaning .github directories from apps..." && \
+    find /home/frappe/frappe-bench/apps -name .github -type d -print -exec rm -rf {} \;
+RUN echo "Cleaning app-level node_modules from apps..." && \
+    find /home/frappe/frappe-bench/apps -name node_modules -type d -print -exec rm -rf {} \;
+RUN echo "Cleaning .pyc files from apps..." && \
+    find /home/frappe/frappe-bench/apps -name '*.pyc' -type f -print -delete
+RUN echo "Cleaning .pyo files from apps..." && \
+    find /home/frappe/frappe-bench/apps -name '*.pyo' -type f -print -delete
+RUN echo "Cleaning __pycache__ directories from apps..." && \
+    find /home/frappe/frappe-bench/apps -name '__pycache__' -type d -print -exec rm -rf {} \;
+RUN echo "Cleaning up main bench sites/.assets/node_modules..." && \
+    rm -rf /home/frappe/frappe-bench/sites/.assets/node_modules
+RUN echo "Cleaning up main bench node_modules..." && \
+    rm -rf /home/frappe/frappe-bench/node_modules
+RUN echo "Cleaning up main bench bower_components..." && \
+    rm -rf /home/frappe/frappe-bench/bower_components
+RUN echo "Comprehensive cleanup separation complete."
 
 # ----------- Final runtime stage ----------
 FROM python:3.11.6-slim-bookworm AS final


### PR DESCRIPTION
This commit modifies the Dockerfile to break down the comprehensive cleanup process in the `builder` stage into multiple separate `RUN` commands.

Previously, a single multi-line `RUN` command executed all cleanup operations (finding and removing .git, .github, node_modules, pyc/pyo files, etc.). This command was failing with an exit code 1 during multi-platform builds.

By separating each major cleanup operation into its own `RUN` instruction, this change aims to pinpoint exactly which `find` or `rm` command is causing the failure, as the Docker build will now stop at the specific failing layer.

This is part of an ongoing effort to ensure the multi-platform Docker build (amd64 and arm64) completes successfully.