### PR TITLE
Fix: Add runner disk cleanup and pin cairocffi

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -33,6 +33,17 @@ jobs:
           echo "FRAPPE_BRANCH_FOR_BUILD=version-$(echo $LATEST | cut -d. -f1 | sed 's/v//')" >> $GITHUB_ENV
           echo "IMAGE_TAG_VERSION=$(echo $LATEST | sed 's/v//')" >> $GITHUB_ENV
 
+      - name: Free up disk space on runner
+        run: |
+          echo "Initial disk space:"
+          df -h
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost /usr/local/lib/android /opt/hostedtoolcache/CodeQL
+          sudo docker system prune -af --volumes
+          sudo apt-get clean || true
+          sudo rm -rf /var/lib/apt/lists/*
+          echo "Disk space after cleanup:"
+          df -h
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,7 @@ RUN . ${NVM_DIR}/nvm.sh && \
 FROM base AS builder
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y     wget libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev libffi-dev liblcms2-dev     libldap2-dev libmariadb-dev libsasl2-dev libtiff5-dev libwebp-dev redis-tools rlwrap tk8.6-dev cron     libmagic1 gcc build-essential libbz2-dev pkg-config  && rm -rf /var/lib/apt/lists/*
 
+RUN pip3 install --no-cache-dir cairocffi==1.5.1
 RUN pip3 install frappe-bench
 
 ARG APPS_JSON_BASE64


### PR DESCRIPTION
This commit introduces measures to improve build stability:

1.  **GitHub Actions Workflow (`.github/workflows/autobuild.yml`):**
    - Added a new step at the beginning of the `build-and-push` job to aggressively free up disk space on the GitHub Actions runner. This includes removing large pre-installed toolsets and pruning Docker system resources.

2.  **Dockerfile (`builder` stage):**
    - Explicitly installs `cairocffi==1.5.1` using `pip3 install --no-cache-dir` before `frappe-bench` is installed. This is to resolve a known dependency conflict where Frappe requires `cairocffi==1.5.1` but other packages might pull in a different version.

These changes aim to address the "No space left on device" errors and Python dependency conflicts that were causing build failures, especially for multi-platform builds.