### PR TITLE
 allow the `find` command to continue processing and the overall `RUN` step to succeed even if `rm -rf` fails

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,8 +77,9 @@ RUN echo "Cleaning up .git directory from frappe app after bench init..." && \
 RUN if [ -n "${APPS_JSON_BASE64}" ]; then echo "${APPS_JSON_BASE64}" | base64 -d > /opt/frappe/apps.json; fi
 COPY apps.json /home/frappe/frappe-bench/apps.json
 RUN /home/frappe/scripts/install_apps.sh
-RUN echo "Cleaning .git directories from apps..." && \
-    find /home/frappe/frappe-bench/apps -name .git -type d -print -exec rm -rf {} \;
+RUN echo "Attempting to clean .git directories from apps (individual rm errors will be ignored)..." && \
+    find /home/frappe/frappe-bench/apps -name .git -type d -print -exec sh -c 'rm -rf "$1" || true' _ {} \; && \
+    echo "Finished attempting to clean .git directories."
 RUN echo "Cleaning .github directories from apps..." && \
     find /home/frappe/frappe-bench/apps -name .github -type d -print -exec rm -rf {} \;
 RUN echo "Cleaning app-level node_modules from apps..." && \


### PR DESCRIPTION
I've modified the Dockerfile's `builder` stage to make the specific `RUN` command for cleaning `.git` directories from apps more resilient.

The `-exec` action for `find` now uses `sh -c 'rm -rf "$1" || true' _ {} \;`. This change is intended to allow the `find` command to continue processing and the overall `RUN` step to succeed even if `rm -rf` fails for some individual `.git` directories. This will help diagnose whether the previous `exit code 1` was due to a specific problematic directory or a more general failure of the `find` or `rm` commands under ARM64 QEMU emulation.

This is part of my ongoing effort to ensure your multi-platform Docker build (amd64 and arm64) completes successfully.