### PR TITLE
Fix: Make runner disk cleanup script more resilient

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -37,11 +37,14 @@ jobs:
         run: |
           echo "Initial disk space:"
           df -h
-          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost /usr/local/lib/android /opt/hostedtoolcache/CodeQL
-          sudo docker system prune -af --volumes
+          echo "Attempting to remove large pre-installed toolsets..."
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost /usr/local/lib/android /opt/hostedtoolcache/CodeQL || true
+          echo "Attempting to prune Docker system..."
+          sudo docker system prune -af --volumes || true
+          echo "Attempting to clean apt cache..."
           sudo apt-get clean || true
-          sudo rm -rf /var/lib/apt/lists/*
-          echo "Disk space after cleanup:"
+          sudo rm -rf /var/lib/apt/lists/* || true
+          echo "Disk space after cleanup attempts:"
           df -h
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
I've modified the "Free up disk space on runner" step in your GitHub Actions workflow (`autobuild.yml`) to be more resilient, particularly for self-hosted environments.

Here's what I changed in the script:
- I appended `|| true` to the commands for removing large toolsets, pruning the system, and cleaning package manager caches. This allows the script to continue even if these specific commands fail (e.g., due to missing tools on a custom self-hosted runner, or if elevated privileges are not configured for passwordless access for these operations).
- I added more `echo` statements for better logging of which parts of the script are being attempted.

This change aims to prevent your workflow from failing prematurely if the self-hosted runner has a different configuration than standard GitHub-hosted runners, allowing the build to proceed to the actual Docker image construction.