### PR TITLE
Fix: Convert all find -exec rm to xargs for cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,16 +83,19 @@ RUN echo "Attempting to list .git directories in apps..." && \
 RUN echo "Attempting to clean .git directories from apps using xargs..." && \
     find /home/frappe/frappe-bench/apps -name .git -type d -print0 | xargs -0 -r rm -rf && \
     echo "Finished cleaning .git directories with xargs."
-RUN echo "Cleaning .github directories from apps..." && \
-    find /home/frappe/frappe-bench/apps -name .github -type d -print -exec rm -rf {} \;
-RUN echo "Cleaning app-level node_modules from apps..." && \
-    find /home/frappe/frappe-bench/apps -name node_modules -type d -print -exec rm -rf {} \;
+RUN echo "Cleaning .github directories from apps using xargs..." && \
+    find /home/frappe/frappe-bench/apps -name .github -type d -print0 | xargs -0 -r rm -rf && \
+    echo "Finished cleaning .github directories with xargs."
+RUN echo "Cleaning app-level node_modules from apps using xargs..." && \
+    find /home/frappe/frappe-bench/apps -name node_modules -type d -print0 | xargs -0 -r rm -rf && \
+    echo "Finished cleaning app-level node_modules with xargs."
 RUN echo "Cleaning .pyc files from apps..." && \
     find /home/frappe/frappe-bench/apps -name '*.pyc' -type f -print -delete
 RUN echo "Cleaning .pyo files from apps..." && \
     find /home/frappe/frappe-bench/apps -name '*.pyo' -type f -print -delete
-RUN echo "Cleaning __pycache__ directories from apps..." && \
-    find /home/frappe/frappe-bench/apps -name '__pycache__' -type d -print -exec rm -rf {} \;
+RUN echo "Cleaning __pycache__ directories from apps using xargs..." && \
+    find /home/frappe/frappe-bench/apps -name '__pycache__' -type d -print0 | xargs -0 -r rm -rf && \
+    echo "Finished cleaning __pycache__ directories with xargs."
 RUN echo "Cleaning up main bench sites/.assets/node_modules..." && \
     rm -rf /home/frappe/frappe-bench/sites/.assets/node_modules
 RUN echo "Cleaning up main bench node_modules..." && \


### PR DESCRIPTION
This commit updates the Dockerfile to use the `find ... -print0 | xargs -0 -r rm -rf` pattern for all applicable cleanup commands in the `builder` stage. This includes the cleanup of:
- `.github` directories within apps
- app-level `node_modules` directories
- `__pycache__` directories

This change is based on previous findings where `find ... -exec rm -rf {} \;` was causing `exit code 1` failures during multi-platform builds (specifically ARM64 emulation), likely due to issues with forking numerous subshells. The `xargs` approach is more robust for these bulk operations.

The `.git` directory cleanup was already successfully converted to `xargs`. This commit extends that pattern to the other similar cleanup operations.

The build will be tested on a self-hosted runner with the full `apps.json` list for both `linux/amd64` and `linux/arm64` platforms.