### PR TITLE
Fix/docker yarn install build linux/amd64 only

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -106,7 +106,7 @@ jobs:
           tags: ${{ env.FINAL_TAGS }}
           build-args: |
             ${{ env.BUILD_ARGS }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
**Goal:** Build for the `linux/amd64` platform using the complete `apps.json` you provided, now that ARM64 emulation is temporarily removed.

**This test will help us understand:**

1.  If we can successfully build for `linux/amd64` with all your applications in a reasonable amount of time.
2.  If there are any other build issues (like dependency conflicts, app-specific errors, or frontend build problems) that aren't related to ARM64 emulation.

**Good news! All the previous stability improvements are still in place:**

*   The workflow runs on a self-hosted environment.
*   The script to clean up disk space on the runner is more resilient.
*   The Dockerfile now includes `python3-dev`.
*   The Dockerfile pins `cairocffi` to version `1.5.1`.
*   The Dockerfile includes a retry loop for `bench init`.
*   The Dockerfile uses `xargs` for all relevant bulk cleanup operations.