### PR TITLE
Fix: Use GHCR_PAT for authentication with GitHub Container Registry

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -19,7 +19,6 @@ jobs:
     env:
       DOCKER_HUB_USERNAME_SET: ${{ secrets.DOCKER_HUB_USERNAME != '' }}
       DOCKER_HUB_ACCESS_TOKEN_SET: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN != '' }}
-      GITHUB_TOKEN_SET: ${{ secrets.GITHUB_TOKEN != '' }}
 
     steps:
       - name: Checkout Repository
@@ -58,12 +57,12 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Log in to GitHub Container Registry
-        if: env.GITHUB_TOKEN_SET == 'true'
+        if: secrets.GHCR_PAT != ''
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GHCR_PAT }}
 
       - name: Prepare Docker Tags
         id: prep_tags
@@ -83,7 +82,7 @@ jobs:
           fi
 
           # Conditionally add GHCR tags
-          if [ "${{ env.GITHUB_TOKEN_SET }}" = "true" ]; then
+          if [ "${{ secrets.GHCR_PAT }}" != "" ]; then
             TAGS="$TAGS,$IMAGE_GH:$TAG"
             TAGS="$TAGS,$IMAGE_GH:$MAJOR"
           fi


### PR DESCRIPTION
Updates the GitHub Actions workflow (`autobuild.yml`) to use a dedicated secret `GHCR_PAT` for authenticating with the GitHub Container Registry (GHCR).

Changes:
- Removed the `GITHUB_TOKEN_SET` environment variable.
- The "Log in to GitHub Container Registry" step now uses `secrets.GHCR_PAT` for the password and is conditional on `secrets.GHCR_PAT` being set.
- The "Prepare Docker Tags" step now conditions the creation of GHCR-specific tags on `secrets.GHCR_PAT` being set.

This change addresses `permission_denied: write_package` errors encountered when pushing to GHCR by using a token with explicit `write:packages` scope, rather than relying on the default `GITHUB_TOKEN`'s permissions.

The build will continue to run on a self-hosted runner for the `linux/amd64` platform only for this test.