### PR TITLE
Fix: Correct syntax for secret checking in workflow 'if' conditions

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -19,6 +19,7 @@ jobs:
     env:
       DOCKER_HUB_USERNAME_SET: ${{ secrets.DOCKER_HUB_USERNAME != '' }}
       DOCKER_HUB_ACCESS_TOKEN_SET: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN != '' }}
+      GHCR_PAT_IS_SET: ${{ secrets.GHCR_PAT != '' }}
 
     steps:
       - name: Checkout Repository
@@ -57,7 +58,7 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Log in to GitHub Container Registry
-        if: secrets.GHCR_PAT != ''
+        if: env.GHCR_PAT_IS_SET == 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -82,7 +83,7 @@ jobs:
           fi
 
           # Conditionally add GHCR tags
-          if [ "${{ secrets.GHCR_PAT }}" != "" ]; then
+          if [ "${{ env.GHCR_PAT_IS_SET }}" = "true" ]; then
             TAGS="$TAGS,$IMAGE_GH:$TAG"
             TAGS="$TAGS,$IMAGE_GH:$MAJOR"
           fi


### PR DESCRIPTION
This commit corrects the syntax used in the `.github/workflows/autobuild.yml` file for checking the presence of the `GHCR_PAT` secret within `if` conditions.

Changes:
- Added a new environment variable `GHCR_PAT_IS_SET` to the `build-and-push` job, which is set to true if `secrets.GHCR_PAT` has a value (`${{ secrets.GHCR_PAT != '' }}`).
- Modified the `if` condition for the "Log in to GitHub Container Registry" step to use `env.GHCR_PAT_IS_SET == 'true'`.
- Modified the bash `if` condition within the "Prepare Docker Tags" step to use `if [ "${{ env.GHCR_PAT_IS_SET }}" = "true" ]; then`.

These changes ensure that the workflow correctly interprets the conditions for GHCR-related steps based on the presence of the `GHCR_PAT` secret, resolving previous workflow validation errors.

The build will run for `linux/amd64` only on a self-hosted runner with the full `apps.json`.